### PR TITLE
ARI-38: Remove Activity tab from roster member detail page

### DIFF
--- a/frontend/src/pages/roster/roster-detail-page.tsx
+++ b/frontend/src/pages/roster/roster-detail-page.tsx
@@ -1,18 +1,15 @@
 import { useParams } from '@tanstack/react-router';
-import { ActivityFeed } from '@/components/activity/activity-feed';
 import { ObjectActions } from '@/components/object-detail';
 import { ObjectDetailTabs } from '@/components/object-detail-tabs';
 import { PageTopBar } from '@/components/page-topbar';
-import { useAuth } from '@/components/providers/auth-provider';
 import { RosterFields } from '@/components/roster-detail';
 import { TabsContent } from '@/components/ui/tabs';
-import { ActionGroupType, ObjectTypes } from '@/openapi/ariveAPI.schemas';
+import { ActionGroupType } from '@/openapi/ariveAPI.schemas';
 import { useRosterIdGetRosterSuspense } from '@/openapi/roster/roster';
 
 export function RosterDetailPage() {
   const { id } = useParams({ from: '/_authenticated/roster/$id' });
   const { data, refetch } = useRosterIdGetRosterSuspense(id);
-  const { user } = useAuth();
 
   return (
     <PageTopBar
@@ -27,14 +24,7 @@ export function RosterDetailPage() {
       }
     >
       <ObjectDetailTabs
-        tabs={[
-          { value: 'summary', label: 'Summary' },
-          {
-            value: 'activity',
-            label: 'Activity',
-            unreadCount: data.thread?.unread_count,
-          },
-        ]}
+        tabs={[{ value: 'summary', label: 'Summary' }]}
         defaultTab="summary"
       >
         <TabsContent value="summary" className="space-y-6">
@@ -45,14 +35,6 @@ export function RosterDetailPage() {
               <RosterFields roster={data} />
             </div>
           </div>
-        </TabsContent>
-
-        <TabsContent value="activity">
-          <ActivityFeed
-            threadableType={ObjectTypes.roster}
-            threadableId={id}
-            currentUserId={user.id as string}
-          />
         </TabsContent>
       </ObjectDetailTabs>
     </PageTopBar>


### PR DESCRIPTION
## Summary

Closes https://linear.app/tryarive/issue/ARI-38

- Removed the Activity tab from the roster member detail page
- Removed the ActivityFeed component and related imports
- Cleaned up unused imports (useAuth, ObjectTypes)

## Implementation Details

The roster detail page previously displayed two tabs: Summary and Activity. Per the ticket requirements, the Activity tab has been removed, leaving only the Summary tab which displays the roster member's information.

Changes made:
- Removed Activity tab definition from the `tabs` array in `ObjectDetailTabs`
- Removed the `TabsContent` component for the Activity tab
- Removed unused imports: `ActivityFeed`, `useAuth`, and `ObjectTypes`
- Removed the `user` variable that was only used by ActivityFeed

## Test Plan

- [x] Type checking passes (frontend)
- [x] Linting passes (frontend)
- [x] Production build succeeds (frontend)
- [ ] Manual testing: Verify roster detail page displays only Summary tab
- [ ] Manual testing: Verify no console errors when viewing roster detail page
- [ ] Reviewed by team

## Linear Ticket

https://linear.app/tryarive/issue/ARI-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)