### PR TITLE
ARI-47: Remove prospect label from roster detail page

### DIFF
--- a/frontend/src/pages/roster/roster-detail-page.tsx
+++ b/frontend/src/pages/roster/roster-detail-page.tsx
@@ -17,7 +17,6 @@ export function RosterDetailPage() {
   return (
     <PageTopBar
       title={data.name}
-      state={data.state}
       actions={
         <ObjectActions
           data={data}


### PR DESCRIPTION
## Summary

Closes https://linear.app/tryarive/issue/ARI-47

- Removed the "Prospect" badge that was displayed next to creator names in the roster detail page
- The state badge was shown in the PageTopBar component and has been removed by not passing the state prop

## Implementation Details

The "Prospect" label was being displayed in the `PageTopBar` component on line 20 of `roster-detail-page.tsx` via the `state={data.state}` prop. By removing this prop, the badge is no longer rendered in the UI while preserving the state data in the backend for potential future use.

## Test Plan

- [x] Type checking passes (frontend)
- [x] Linting passes (frontend)
- [x] Production build succeeds (frontend)
- [ ] Manual testing completed
- [ ] Reviewed by team

## Linear Ticket

https://linear.app/tryarive/issue/ARI-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)