### PR TITLE
ARI-46: Create UI for Creator Details

### DIFF
--- a/frontend/src/components/roster-detail/creator-metrics.tsx
+++ b/frontend/src/components/roster-detail/creator-metrics.tsx
@@ -1,0 +1,131 @@
+import { DollarSign, TrendingUp, Users, Eye, Heart, BarChart3 } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import type { RosterSchema } from '@/openapi/ariveAPI.schemas';
+
+interface CreatorMetricsProps {
+  roster: RosterSchema;
+}
+
+interface MetricItemProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  subtext?: string;
+}
+
+function MetricItem({ icon, label, value, subtext }: MetricItemProps) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="bg-muted flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg">
+        {icon}
+      </div>
+      <div className="flex-1 space-y-1">
+        <div className="text-muted-foreground text-sm">{label}</div>
+        <div className="text-xl font-semibold">{value}</div>
+        {subtext && (
+          <div className="text-muted-foreground text-xs">{subtext}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CreatorMetrics({ roster: _roster }: CreatorMetricsProps) {
+  // TODO: Replace with real data from backend once available
+  // These are placeholder values to demonstrate the UI structure
+  // The roster prop will be used once backend metrics are available
+  const financialMetrics = {
+    totalRevenue: '$0',
+    activeCampaigns: 0,
+    accountsReceivable: '$0',
+    accountsPayable: '$0',
+  };
+
+  const socialMetrics = {
+    totalFollowers: 0,
+    engagementRate: '0%',
+    avgViews: 0,
+    recentContent: 0,
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Financial Metrics */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <DollarSign className="h-5 w-5" />
+            Financial Performance
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <MetricItem
+            icon={<TrendingUp className="text-muted-foreground h-5 w-5" />}
+            label="Total Revenue"
+            value={financialMetrics.totalRevenue}
+            subtext="All-time earnings"
+          />
+          <MetricItem
+            icon={<BarChart3 className="text-muted-foreground h-5 w-5" />}
+            label="Active Campaigns"
+            value={financialMetrics.activeCampaigns}
+            subtext="Currently running"
+          />
+          <MetricItem
+            icon={<DollarSign className="text-muted-foreground h-5 w-5" />}
+            label="Accounts Receivable"
+            value={financialMetrics.accountsReceivable}
+            subtext="Pending payments"
+          />
+          <MetricItem
+            icon={<DollarSign className="text-muted-foreground h-5 w-5" />}
+            label="Accounts Payable"
+            value={financialMetrics.accountsPayable}
+            subtext="Owed to creator"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Social Media Performance */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Social Performance
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <MetricItem
+            icon={<Users className="text-muted-foreground h-5 w-5" />}
+            label="Total Followers"
+            value={socialMetrics.totalFollowers.toLocaleString()}
+            subtext="Across all platforms"
+          />
+          <MetricItem
+            icon={<Heart className="text-muted-foreground h-5 w-5" />}
+            label="Engagement Rate"
+            value={socialMetrics.engagementRate}
+            subtext="Avg. across platforms"
+          />
+          <MetricItem
+            icon={<Eye className="text-muted-foreground h-5 w-5" />}
+            label="Average Views"
+            value={socialMetrics.avgViews.toLocaleString()}
+            subtext="Last 10 videos"
+          />
+          <MetricItem
+            icon={<BarChart3 className="text-muted-foreground h-5 w-5" />}
+            label="Recent Content"
+            value={socialMetrics.recentContent}
+            subtext="Last 30 days"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/roster-detail/index.ts
+++ b/frontend/src/components/roster-detail/index.ts
@@ -1,1 +1,2 @@
 export { RosterFields } from './roster-fields';
+export { CreatorMetrics } from './creator-metrics';

--- a/frontend/src/pages/roster/roster-detail-page.tsx
+++ b/frontend/src/pages/roster/roster-detail-page.tsx
@@ -2,7 +2,7 @@ import { useParams } from '@tanstack/react-router';
 import { ObjectActions } from '@/components/object-detail';
 import { ObjectDetailTabs } from '@/components/object-detail-tabs';
 import { PageTopBar } from '@/components/page-topbar';
-import { RosterFields } from '@/components/roster-detail';
+import { RosterFields, CreatorMetrics } from '@/components/roster-detail';
 import { TabsContent } from '@/components/ui/tabs';
 import { ActionGroupType } from '@/openapi/ariveAPI.schemas';
 import { useRosterIdGetRosterSuspense } from '@/openapi/roster/roster';
@@ -24,7 +24,7 @@ export function RosterDetailPage() {
       }
     >
       <ObjectDetailTabs
-        tabs={[{ value: 'summary', label: 'Summary' }]}
+        tabs={[{ value: 'summary', label: 'Creator Details' }]}
         defaultTab="summary"
       >
         <TabsContent value="summary" className="space-y-6">
@@ -33,6 +33,9 @@ export function RosterDetailPage() {
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
               {/* Left Column - Fields */}
               <RosterFields roster={data} />
+
+              {/* Right Column - Performance Metrics */}
+              <CreatorMetrics roster={data} />
             </div>
           </div>
         </TabsContent>


### PR DESCRIPTION
## Summary

Closes https://linear.app/tryarive/issue/ARI-46

- Renamed "Summary" tab to "Creator Details" in roster detail page
- Created comprehensive CreatorMetrics component displaying financial and social performance
- Added Financial Performance card with revenue, campaigns, AR/AP metrics
- Added Social Performance card with followers, engagement rate, average views, and recent content metrics
- Implemented responsive two-column layout (left: contact/demographic fields, right: performance metrics)

## Implementation Details

**New Component: CreatorMetrics**
- Location: `frontend/src/components/roster-detail/creator-metrics.tsx`
- Two card layout: Financial Performance and Social Performance
- Uses MetricItem sub-component for consistent metric display with icons
- Follows design system patterns from existing stat-widget component
- Currently displays placeholder/zero values with TODO comments for backend integration

**Layout Updates:**
- Updated `roster-detail-page.tsx` to include CreatorMetrics in right column
- Maintains responsive grid: stacks on mobile, two-column on large screens
- Left column: RosterFields (existing contact/demographic data)
- Right column: CreatorMetrics (new performance metrics)

**Design Patterns:**
- Uses shadcn/ui Card components for consistent styling
- Lucide React icons for visual hierarchy
- Muted background for metric icons
- Clear labels with primary values and supporting subtext
- Ready for real data once backend metrics endpoints are available

## Test Plan

- [x] Type checking passes (frontend)
- [x] Linting passes (frontend)
- [x] Production build succeeds (frontend)
- [ ] Manual testing: Verify tab renamed to "Creator Details"
- [ ] Manual testing: Verify metrics cards display correctly on desktop and mobile
- [ ] Manual testing: Verify layout matches Figma design intent
- [ ] Reviewed by team

## Future Work

Once backend performance metrics are available:
1. Replace placeholder values in `financialMetrics` with real data from roster schema
2. Replace placeholder values in `socialMetrics` with real data from roster schema
3. Add trend indicators (up/down arrows) similar to dashboard stat widgets
4. Consider adding time-based filtering (last 30 days, all-time, etc.)

## Linear Ticket

https://linear.app/tryarive/issue/ARI-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)